### PR TITLE
Add table creation to examples.

### DIFF
--- a/examples/basic.py
+++ b/examples/basic.py
@@ -16,9 +16,20 @@ class User(db.Model):
 
 
 async def main():
-    conn = await asyncpg.connect('postgresql://localhost/gino')
+    # Database endpoint.
+    db_endpoint = 'postgresql://localhost/gino'
 
-    # You will need to create the database and table manually
+    # In this example we create the database tables directly using SQLAlchemy
+    # and non-async Postgres (uses psycopg2 python module, not asyncpg which
+    # Gino uses). For a production application you would probably use a full
+    # schema migration solution like Alembic.
+    import sqlalchemy as sa
+    db_engine = sa.create_engine(db_endpoint)
+    db.create_all(bind=db_engine)
+    db_engine.dispose()
+
+    # Here starts the normal async application
+    conn = await asyncpg.connect(db_endpoint)
 
     print(await User.create(bind=conn, nickname='fantix'))
     print(await User.get(1, bind=conn))


### PR DESCRIPTION
To make it easier for people to run the examples "as is" we could add automatic table creation.

This PR does this for the first basic example.

Should this be a separate example? Should we add it to all of them? I can do either.

Thoughts @fantix?
