### PR TITLE
Implement better JOIN semantics

### DIFF
--- a/gino/declarative.py
+++ b/gino/declarative.py
@@ -29,7 +29,7 @@ class ModelType(type):
 
     def __getattr__(self, item):
         try:
-            if item in {'insert'}:
+            if item in {'insert', 'join'}:
                 return getattr(self.__table__, item)
             raise AttributeError
         except AttributeError:
@@ -84,6 +84,11 @@ class Model:
 
 def declarative_base(metadata, model_classes=(Model,), name='Model'):
     return ModelType(name, model_classes, {'__metadata__': metadata})
+
+
+@sa.inspection._inspects(ModelType)
+def inspect_model_type(target):
+    return sa.inspection.inspect(target.__table__)
 
 
 __all__ = ['ColumnAttribute', 'Model', 'declarative_base']


### PR DESCRIPTION
This PR does two things:

1. It exposes `join()`  from the underlying `sqlalchemy.schema.Table` directly onto `gino.declarative.ModelType`. `insert()` was already exposed, see:
https://github.com/fantix/gino/blob/master/gino/declarative.py#L32.

2. It registers `gino.declarative.ModelType` as an "inspectable" type to SQLAlchemy, by dispatching the inspection to, again, the model's underlying table.

These changes allow for friendlier semantics when writing `JOIN` queries (see #112):

```py
Model1.join(Model2)
```

instead of

```py
Model1.__table__.join(Model2.__table__)
```
also

```py
import join from sqlalchemy
join(Model1, Model2)
```

instead of

```py
import join from sqlalchemy
join(Model1.__table__, Model2.__table__)
```