### PR TITLE
Fix lazy connections

### DIFF
--- a/gino/dialect.py
+++ b/gino/dialect.py
@@ -10,6 +10,7 @@ from sqlalchemy.dialects.postgresql.base import (
     PGDialect,
     PGExecutionContext,
 )
+from .pool import LazyConnection
 
 DEFAULT = object()
 
@@ -241,7 +242,8 @@ class AsyncpgDialect(PGDialect):
         if context.executemany and not many:
             raise ValueError('too many multiparams')
         # noinspection PyProtectedMember
-        await connection.get_connection()
+        if isinstance(connection, LazyConnection):
+            await connection.get_connection()
         with connection._stmt_exclusive_section:
             prepared = await context.prepare(named=False)
             rv = []

--- a/gino/dialect.py
+++ b/gino/dialect.py
@@ -241,6 +241,7 @@ class AsyncpgDialect(PGDialect):
         if context.executemany and not many:
             raise ValueError('too many multiparams')
         # noinspection PyProtectedMember
+        await connection.get_connection()
         with connection._stmt_exclusive_section:
             prepared = await context.prepare(named=False)
             rv = []


### PR DESCRIPTION
#90 seems to have broken the lazy connection use cases (Sanic/Tornado extensions):

```
 [... traceback continues here ...]
  File "/usr/local/lib/python3.6/site-packages/gino/api.py", line 126, in scalar
    conn, self._query, *multiparams, **params)
  File "/usr/local/lib/python3.6/site-packages/gino/dialect.py", line 270, in do_scalar
    connection, clause, multiparams, params, return_model=False)
  File "/usr/local/lib/python3.6/site-packages/gino/dialect.py", line 244, in _execute_clauseelement
    with connection._stmt_exclusive_section:
  File "/usr/local/lib/python3.6/site-packages/gino/pool.py", line 101, in __getattr__
    'Connection is not ready yet, or has been released')
asyncpg.exceptions._base.InterfaceError: Connection is not ready yet, or has been released
```

The new prepared statement stuff tries to acquire the `LazyConnection._stmt_exclusive_section` mutex but fails to ensure the connection actually exists.

This is because `LazyConnection.__getattr__()` calls `get_connection()` _only_ when the attribute is a coroutine, and expects `get_connection()` to have already been called in any other case.

The PR fixes this by explicitly calling `LazyConnection.get_connection()` before acquiring the mutex.

I admittedly do not understand the changes in #90, so there might be similar unfixed code paths, I haven't checked thoroughly :).