### PR TITLE
Problem when use enum type and create model

### DIFF
--- a/gino/crud.py
+++ b/gino/crud.py
@@ -176,7 +176,8 @@ class CRUDModel(Model):
         if timeout is not DEFAULT:
             opts['timeout'] = timeout
         q = cls.__table__.insert().values(**rv.__values__).returning(
-            sa.text('*')).execution_options(**opts)
+            *cls.__table__.columns
+        ).execution_options(**opts)
         row = await cls.__metadata__.first(q, bind=bind)
         rv.__values__.update(row)
         rv.__profile__ = None

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,4 +1,5 @@
 import os
+import enum
 
 from gino import Gino
 
@@ -12,11 +13,20 @@ DB_ARGS = dict(
 db = Gino()
 
 
+class UserType(enum.Enum):
+    USER = 'USER'
+
+
 class User(db.Model):
     __tablename__ = 'gino_users'
 
     id = db.Column(db.BigInteger(), primary_key=True)
     nickname = db.Column(db.Unicode(), default='noname')
+    type = db.Column(
+        db.Enum(UserType),
+        nullable=False,
+        default=UserType.USER,
+    )
 
     def __repr__(self):
         return '{}<{}>'.format(self.nickname, self.id)

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,16 +1,17 @@
 import random
 
 import pytest
-from .models import User, Friendship
+from .models import User, UserType, Friendship
 
 pytestmark = pytest.mark.asyncio
 
 
 async def test_create(asyncpg_pool):
     nickname = 'test_create_{}'.format(random.random())
-    u = await User.create(bind=asyncpg_pool, nickname=nickname)
+    u = await User.create(bind=asyncpg_pool, nickname=nickname, type=UserType.USER)
     assert u.id is not None
     assert u.nickname == nickname
+    assert u.type == UserType.USER
     return u
 
 


### PR DESCRIPTION
* GINO version: 0.5.7
* Python version: 3.6
* Operating System: MAC OS

### Description

I'm trying to create object using GINO, but sqlalchemy does not resolve enum type, when object is created. The problem is that sqlalchemy does not know about returning fields, when '*' is used. 

### What I Did
I found possible solution is to send all columns directly
https://github.com/Reskov/gino/commit/a017775b78d008684b2857646ca3c98294b63c62

May you review is it ok?
