### PR TITLE
Added result loader

### DIFF
--- a/docs/index.rst
+++ b/docs/index.rst
@@ -61,6 +61,7 @@ Contents
    engine
    transaction
    crud
+   relationship
    sanic
    tornado
    adv_topics

--- a/docs/relationship.rst
+++ b/docs/relationship.rst
@@ -1,0 +1,5 @@
+=============
+Relationships
+=============
+
+**THIS IS A WIP**

--- a/gino/api.py
+++ b/gino/api.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql.schema import SchemaItem
 
 from .crud import CRUDModel
 from .declarative import declarative_base
+from .loader import Loader
 from .schema import GinoSchemaVisitor, patch_schema
 from . import json_support
 
@@ -95,6 +96,22 @@ class GinoExecutor:
 
         """
         self._query = self._query.execution_options(timeout=timeout)
+        return self
+
+    def load(self, value):
+        """
+        Shortcut to set execution option ``loader`` in a chaining call.
+
+        For example to load ``Book`` instances with their authors::
+
+            query = Book.join(User).select()
+            books = await query.gino.load(Book.load(author=User)).all()
+
+        Read :meth:`~gino.engine.GinoConnection.execution_options` for more
+        information.
+
+        """
+        self._query = self._query.execution_options(loader=Loader.get(value))
         return self
 
     async def all(self, *multiparams, **params):

--- a/gino/api.py
+++ b/gino/api.py
@@ -7,7 +7,6 @@ from sqlalchemy.sql.schema import SchemaItem
 
 from .crud import CRUDModel
 from .declarative import declarative_base
-from .loader import Loader
 from .schema import GinoSchemaVisitor, patch_schema
 from . import json_support
 
@@ -111,7 +110,7 @@ class GinoExecutor:
         information.
 
         """
-        self._query = self._query.execution_options(loader=Loader.get(value))
+        self._query = self._query.execution_options(loader=value)
         return self
 
     async def all(self, *multiparams, **params):

--- a/gino/crud.py
+++ b/gino/crud.py
@@ -7,6 +7,7 @@ from sqlalchemy.sql import ClauseElement
 from . import json_support
 from .declarative import Model
 from .exceptions import NoSuchRowError
+from .loader import ModelLoader
 
 DEFAULT = object()
 
@@ -509,3 +510,7 @@ class CRUDModel(Model):
                 keys.add(key)
                 keys.discard(prop.column_name)
         return dict((k, getattr(self, k)) for k in keys)
+
+    @classmethod
+    def load(cls, *column_names, **relationships):
+        return ModelLoader(cls, *column_names, **relationships)

--- a/gino/crud.py
+++ b/gino/crud.py
@@ -513,4 +513,48 @@ class CRUDModel(Model):
 
     @classmethod
     def load(cls, *column_names, **relationships):
+        """
+        Populates a :class:`.loader.Loader` instance to be used by the
+        ``loader`` execution option in order to customize the loading behavior
+        to load specified fields into instances of this model.
+
+        This method shouldn't be used alone (if you are looking for reloading
+        the instance from database, check :meth:`.get` or :attr:`.query`), it
+        is usually given to the ``loader`` execution option.
+
+        This method takes both positional arguments and keyword arguments with
+        very different meanings. The positional arguments should be column
+        names as strings, specifying only these columns should be loaded into
+        the model instance (other values are discarded even if they are
+        retrieved from database). Meanwhile, the keyword arguments should be
+        loaders for instance attributes. For example::
+
+            u = await User.query.gino.load(User.load('id', 'name')).first()
+
+        .. tip::
+
+            ``gino.load`` is a shortcut for setting the execution option
+            ``loader``.
+
+        This will populate a ``User`` instance with only ``id`` and ``name``
+        values, all the rest are simply ``None`` even if the query actually
+        returned all the column values.
+
+        ::
+
+            q = User.join(Team).select()
+            u = await q.gino.load(User.load(team=Team)).first()
+
+        This will load two instances of model ``User`` and ``Team``, returning
+        the ``User`` instance with ``u.team`` set to the ``Team`` instance.
+
+        Both positional and keyword arguments can be used ath the same time. If
+        they are both omitted, like ``Team.load()``, it is equivalent to just
+        ``Team`` as a loader.
+
+        .. seealso::
+
+            :meth:`~gino.engine.GinoConnection.execution_options`
+
+        """
         return ModelLoader(cls, *column_names, **relationships)

--- a/gino/dialects/base.py
+++ b/gino/dialects/base.py
@@ -230,7 +230,7 @@ class ExecutionContextOverride:
         if loader is not None and return_model and self.return_model:
             rv = []
             for row in rows:
-                obj = Loader.get(loader).load(row, None)
+                obj = Loader.get(loader).do_load(row, None)
                 rv.append(obj)
         return rv
 

--- a/gino/dialects/base.py
+++ b/gino/dialects/base.py
@@ -230,7 +230,7 @@ class ExecutionContextOverride:
         if loader is not None and return_model and self.return_model:
             rv = []
             for row in rows:
-                obj = loader.load(row, None)
+                obj = Loader.get(loader).load(row, None)
                 rv.append(obj)
         return rv
 

--- a/gino/dialects/base.py
+++ b/gino/dialects/base.py
@@ -5,6 +5,7 @@ from sqlalchemy import util
 
 # noinspection PyProtectedMember
 from ..engine import _SAConnection, _SAEngine, _DBAPIConnection
+from ..loader import Loader
 
 DEFAULT = object()
 
@@ -216,13 +217,20 @@ class ExecutionContextOverride:
     def timeout(self):
         return self._compiled_first_opt('timeout', None)
 
+    @util.memoized_property
+    def loader(self):
+        return self._compiled_first_opt('loader', None)
+
     def process_rows(self, rows, return_model=True):
         # noinspection PyUnresolvedReferences
         rv = rows = super().get_result_proxy().process_rows(rows)
-        if self.model is not None and return_model and self.return_model:
+        loader = self.loader
+        if loader is None and self.model is not None:
+            loader = Loader.get(self.model)
+        if loader is not None and return_model and self.return_model:
             rv = []
             for row in rows:
-                obj = self.model()
+                obj = loader.load(row, None)
                 obj.__values__.update(row)
                 rv.append(obj)
         return rv

--- a/gino/dialects/base.py
+++ b/gino/dialects/base.py
@@ -231,7 +231,6 @@ class ExecutionContextOverride:
             rv = []
             for row in rows:
                 obj = loader.load(row, None)
-                obj.__values__.update(row)
                 rv.append(obj)
         return rv
 

--- a/gino/engine.py
+++ b/gino/engine.py
@@ -473,6 +473,28 @@ class GinoConnection:
         :param timeout: Seconds to wait for the query to finish. ``None`` for
           no time out (default).
 
+        :param loader: A loader expression to load the database rows into
+          specified objective structure. It can be either:
+
+          * A model class, so that the query will yield model instances of this
+            class. It is your responsibility to make sure all the columns of
+            this model is selected in the query.
+          * A :class:`~sqlalchemy.schema.Column` instance, so that each result
+            will be only a single value of this column. Please note, if you
+            want to achieve fetching the very first value, you should use
+            :meth:`~gino.engine.GinoConnection.first` instead of
+            :meth:`~gino.engine.GinoConnection.scalar`. However, using directly
+            :meth:`~gino.engine.GinoConnection.scalar` is a more direct way.
+          * A tuple nesting more loader expressions recursively.
+          * A :func:`callable` function that will be called for each row to
+            fully customize the result. Two positional arguments will be passed
+            to the function: the first is the :class:`row
+            <sqlalchemy.engine.RowProxy>` instance, the second is a context
+            object which is only present if nested else ``None``.
+          * A :class:`~gino.loader.Loader` instance directly.
+          * Anything else will be treated as literal values thus returned as
+            whatever they are.
+
         """
         return type(self)(self._dialect,
                           self._sa_conn.execution_options(**opt))

--- a/gino/loader.py
+++ b/gino/loader.py
@@ -9,7 +9,7 @@ class Loader:
     def get(cls, value):
         if isinstance(value, Loader):
             rv = value
-        elif issubclass(value, Model):
+        elif isinstance(value, type) and issubclass(value, Model):
             rv = ModelLoader(value)
         elif isinstance(value, Column):
             rv = ColumnLoader(value)
@@ -39,7 +39,7 @@ class ModelLoader(Loader):
         rv = self.model()
         for c in self.columns:
             rv.__values__[c.name] = row[c]
-        for key, value in self.relationships:
+        for key, value in self.relationships.items():
             setattr(rv, key, value.load(row, rv))
         return rv
 
@@ -57,7 +57,7 @@ class TupleLoader(Loader):
         self.loaders = (self.get(value) for value in values)
 
     def load(self, row, context):
-        return (loader.load(row, context) for loader in self.loaders)
+        return tuple(loader.load(row, context) for loader in self.loaders)
 
 
 class CallableLoader(Loader):

--- a/gino/loader.py
+++ b/gino/loader.py
@@ -7,10 +7,14 @@ class Loader:
 
     @classmethod
     def get(cls, value):
+        from .crud import Alias
+
         if isinstance(value, Loader):
             rv = value
         elif isinstance(value, type) and issubclass(value, Model):
             rv = ModelLoader(value)
+        elif isinstance(value, Alias):
+            rv = AliasLoader(value)
         elif isinstance(value, Column):
             rv = ColumnLoader(value)
         elif isinstance(value, tuple):
@@ -42,6 +46,12 @@ class ModelLoader(Loader):
         for key, value in self.relationships.items():
             setattr(rv, key, value.load(row, rv))
         return rv
+
+
+class AliasLoader(ModelLoader):
+    def __init__(self, alias, *column_names, **relationships):
+        super().__init__(alias, *column_names, **relationships)
+        self.model = alias.model
 
 
 class ColumnLoader(Loader):

--- a/gino/loader.py
+++ b/gino/loader.py
@@ -5,8 +5,6 @@ from .declarative import Model
 
 
 class Loader:
-    one = True
-
     @classmethod
     def get(cls, value):
         from .crud import Alias

--- a/gino/loader.py
+++ b/gino/loader.py
@@ -1,0 +1,76 @@
+from sqlalchemy.schema import Column
+from .declarative import Model
+
+
+class Loader:
+    one = True
+
+    @classmethod
+    def get(cls, value):
+        if isinstance(value, Loader):
+            rv = value
+        elif issubclass(value, Model):
+            rv = ModelLoader(value)
+        elif isinstance(value, Column):
+            rv = ColumnLoader(value)
+        elif isinstance(value, tuple):
+            rv = TupleLoader(value)
+        elif callable(value):
+            rv = CallableLoader(value)
+        else:
+            rv = ValueLoader(value)
+        return rv
+
+    def load(self, row, context):
+        raise NotImplementedError
+
+
+class ModelLoader(Loader):
+    def __init__(self, model, *column_names, **relationships):
+        self.model = model
+        if column_names:
+            self.columns = [getattr(model, name) for name in column_names]
+        else:
+            self.columns = model
+        self.relationships = dict((key, self.get(value))
+                                  for key, value in relationships.items())
+
+    def load(self, row, context):
+        rv = self.model()
+        for c in self.columns:
+            rv.__values__[c.name] = row[c]
+        for key, value in self.relationships:
+            setattr(rv, key, value.load(row, rv))
+        return rv
+
+
+class ColumnLoader(Loader):
+    def __init__(self, column):
+        self.column = column
+
+    def load(self, row, context):
+        return row[self.column]
+
+
+class TupleLoader(Loader):
+    def __init__(self, values):
+        self.loaders = (self.get(value) for value in values)
+
+    def load(self, row, context):
+        return (loader.load(row, context) for loader in self.loaders)
+
+
+class CallableLoader(Loader):
+    def __init__(self, func):
+        self.func = func
+
+    def load(self, row, context):
+        return self.func(row, context)
+
+
+class ValueLoader(Loader):
+    def __init__(self, value):
+        self.value = value
+
+    def load(self, row, context):
+        return self.value

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,13 +1,10 @@
-import random
-import string
-
 import asyncpg
 import pytest
 import sqlalchemy
 from async_generator import yield_, async_generator
 
 import gino
-from .models import db, DB_ARGS, PG_URL
+from .models import db, DB_ARGS, PG_URL, random_name
 
 ECHO = False
 
@@ -48,6 +45,4 @@ async def asyncpg_pool(sa_engine):
         await rv.execute('DELETE FROM gino_users')
 
 
-@pytest.fixture
-def random_name(length=8) -> str:
-    return ''.join(random.choice(string.ascii_letters) for _ in range(length))
+pytest.fixture(random_name)

--- a/tests/models.py
+++ b/tests/models.py
@@ -1,5 +1,7 @@
 import os
 import enum
+import random
+import string
 from datetime import datetime
 
 from gino import Gino
@@ -15,6 +17,10 @@ DB_ARGS = dict(
 PG_URL = 'postgresql://{user}:{password}@{host}:{port}/{database}'.format(
     **DB_ARGS)
 db = Gino()
+
+
+def random_name(length=8) -> str:
+    return ''.join(random.choice(string.ascii_letters) for _ in range(length))
 
 
 class UserType(enum.Enum):
@@ -69,6 +75,7 @@ class Team(db.Model):
     __tablename__ = 'gino_teams'
 
     id = db.Column(db.BigInteger(), primary_key=True)
+    name = db.Column(db.Unicode(), default=random_name)
     parent_id = db.Column(db.ForeignKey('gino_teams.id'))
     company_id = db.Column(db.ForeignKey('gino_companies.id'))
 
@@ -77,6 +84,7 @@ class Company(db.Model):
     __tablename__ = 'gino_companies'
 
     id = db.Column(db.BigInteger(), primary_key=True)
+    name = db.Column(db.Unicode(), default=random_name)
 
 
 def qsize(engine):

--- a/tests/models.py
+++ b/tests/models.py
@@ -37,6 +37,7 @@ class User(db.Model):
     balance = db.IntegerProperty(default=0)
     birthday = db.DateTimeProperty(
         default=lambda i: datetime.utcfromtimestamp(0))
+    team_id = db.Column(db.ForeignKey('gino_teams.id'))
 
     @balance.after_get
     def balance(self, val):
@@ -62,6 +63,20 @@ class Relation(db.Model):
     __tablename__ = 'gino_relation'
 
     name = db.Column(db.Text(), primary_key=True)
+
+
+class Team(db.Model):
+    __tablename__ = 'gino_teams'
+
+    id = db.Column(db.BigInteger(), primary_key=True)
+    parent_id = db.Column(db.ForeignKey('gino_teams.id'))
+    company_id = db.Column(db.ForeignKey('gino_companies.id'))
+
+
+class Company(db.Model):
+    __tablename__ = 'gino_companies'
+
+    id = db.Column(db.BigInteger(), primary_key=True)
 
 
 def qsize(engine):

--- a/tests/test_execution_options.py
+++ b/tests/test_execution_options.py
@@ -45,20 +45,23 @@ async def test_query_ext(bind):
     assert not isinstance(row, User)
     assert row == (
         u.id, 'test', {'age': 18, 'birthday': '1970-01-01T00:00:00.000000'},
-        UserType.USER)
+        UserType.USER, None)
 
     row = await User.query.gino.model(None).first()
     assert not isinstance(row, User)
     assert row == (
         u.id, 'test', {'age': 18, 'birthday': '1970-01-01T00:00:00.000000'},
-        UserType.USER)
+        UserType.USER, None)
 
     row = await db.select([User.id, User.nickname, User.type]).gino.first()
     assert not isinstance(row, User)
     assert row == (u.id, 'test', UserType.USER)
 
     user = await db.select(
-        [User.id, User.nickname, User.type]).gino.model(User).first()
+        [User.id, User.nickname, User.type]
+    ).execution_options(
+        loader=User.load('id', 'nickname', 'type')
+    ).gino.first()
     assert isinstance(user, User)
     assert user.id is not None
     assert user.nickname == 'test'

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -23,7 +23,7 @@ async def test_crud(bind):
     u = await User.create(nickname='fantix', birthday=now)
     u.age += 1
     assert await u.query.gino.model(None).first() == (
-        1, 'fantix', {'age': 18, 'birthday': now_str}, UserType.USER)
+        1, 'fantix', {'age': 18, 'birthday': now_str}, UserType.USER, None)
 
     u = await User.get(u.id)
     assert u.nickname == 'fantix'
@@ -46,7 +46,7 @@ async def test_crud(bind):
     assert isinstance(u.balance, float)
     assert await u.query.gino.model(None).first() == (
         1, 'fantix', dict(age=16, balance=100, birthday=now_str),
-        UserType.USER)
+        UserType.USER, None)
     assert await db.select([User.name]).where(
         User.id == u.id).gino.scalar() is None
 
@@ -56,7 +56,7 @@ async def test_crud(bind):
                    nickname='daisy').apply()
     assert await u.query.gino.model(None).first() == (
         1, 'daisy', dict(age=14, balance=200, name='daisy', birthday=now_str),
-        UserType.USER)
+        UserType.USER, None)
     assert u.to_dict() == dict(
         age=14,
         balance=200.0,
@@ -65,6 +65,7 @@ async def test_crud(bind):
         name='daisy',
         nickname='daisy',
         type=UserType.USER,
+        team_id=None,
     )
 
     # Deleting property doesn't affect database

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -2,6 +2,7 @@ import random
 from datetime import datetime
 
 import pytest
+from async_generator import yield_, async_generator
 
 from .models import db, User, Team, Company
 
@@ -9,6 +10,7 @@ pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
+@async_generator
 async def user(bind, random_name):
     c = await Company.create()
     t1 = await Team.create(company_id=c.id)
@@ -18,7 +20,7 @@ async def user(bind, random_name):
     t2.parent = t1
     t2.company = c
     t1.company = c
-    yield u
+    await yield_(u)
     await User.delete.gino.status()
     await Team.delete.gino.status()
     await Company.delete.gino.status()

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,8 +1,131 @@
+import random
+from datetime import datetime
+
 import pytest
+
+from .models import db, User, Team, Company
 
 pytestmark = pytest.mark.asyncio
 
 
 @pytest.fixture
-async def data():
-    pass
+async def user(bind, random_name):
+    c = await Company.create()
+    t1 = await Team.create(company_id=c.id)
+    t2 = await Team.create(company_id=c.id, parent_id=t1.id)
+    u = await User.create(nickname=random_name, team_id=t2.id)
+    u.team = t2
+    t2.parent = t1
+    t2.company = c
+    t1.company = c
+    yield u
+    await User.delete.gino.status()
+    await Team.delete.gino.status()
+    await Company.delete.gino.status()
+
+
+async def test_model_alternative(user):
+    u = await User.query.gino.load(User).first()
+    assert isinstance(u, User)
+    assert u.id == user.id
+    assert u.nickname == user.nickname
+
+
+async def test_scalar(user):
+    name = await User.query.gino.load(User.nickname).first()
+    assert user.nickname == name
+
+    uid, name = await User.query.gino.load((User.id, User.nickname)).first()
+    assert user.id == uid
+    assert user.nickname == name
+
+
+async def test_model_load(user):
+    u = await User.query.gino.load(User.load('nickname')).first()
+    assert isinstance(u, User)
+    assert u.id is None
+    assert u.nickname == user.nickname
+
+
+async def test_load_relationship(user):
+    u = await User.outerjoin(Team).select().gino.load(
+        User.load(team=Team)).first()
+    assert isinstance(u, User)
+    assert u.id == user.id
+    assert u.nickname == user.nickname
+    assert isinstance(u.team, Team)
+    assert u.team.id == user.team.id
+    assert u.team.name == user.team.name
+
+
+async def test_load_nested(user):
+    u = await User.outerjoin(Team).outerjoin(Company).select().gino.load(
+        User.load(team=Team.load(company=Company))).first()
+    assert isinstance(u, User)
+    assert u.id == user.id
+    assert u.nickname == user.nickname
+    assert isinstance(u.team, Team)
+    assert u.team.id == user.team.id
+    assert u.team.name == user.team.name
+    assert isinstance(u.team.company, Company)
+    assert u.team.company.id == user.team.company.id
+    assert u.team.company.name == user.team.company.name
+
+
+async def test_func(user):
+    def loader(row, context):
+        rv = User(id=row[User.id], nickname=row[User.nickname])
+        rv.team = Team(id=row[Team.id], name=row[Team.name])
+        rv.team.company = Company(id=row[Company.id], name=row[Company.name])
+        return rv
+
+    u = await User.outerjoin(Team).outerjoin(Company).select().gino.load(
+        loader).first()
+    assert isinstance(u, User)
+    assert u.id == user.id
+    assert u.nickname == user.nickname
+    assert isinstance(u.team, Team)
+    assert u.team.id == user.team.id
+    assert u.team.name == user.team.name
+    assert isinstance(u.team.company, Company)
+    assert u.team.company.id == user.team.company.id
+    assert u.team.company.name == user.team.company.name
+
+
+async def test_adjaceny_list(user):
+    Group = Team.__table__.alias()
+
+    def loader(row, context):
+        rv = User(id=row[User.id], nickname=row[User.nickname])
+        rv.team = Team(id=row[Team.id], name=row[Team.name])
+        rv.team.parent = Team(id=row[Group.c.id], name=row[Group.c.name])
+        return rv
+
+    u = await User.outerjoin(
+        Team
+    ).outerjoin(
+        Group, Team.parent_id == Group.c.id
+    ).select().gino.load(loader).first()
+
+    assert isinstance(u, User)
+    assert u.id == user.id
+    assert u.nickname == user.nickname
+    assert isinstance(u.team, Team)
+    assert u.team.id == user.team.id
+    assert u.team.name == user.team.name
+    assert isinstance(u.team.parent, Team)
+    assert u.team.parent.id == user.team.parent.id
+    assert u.team.parent.name == user.team.parent.name
+
+
+async def test_literal(user):
+    sample = tuple(random.random() for _ in range(5))
+    now = db.Column('time', db.DateTime())
+    row = await db.first(db.text(
+        'SELECT now() AT TIME ZONE \'UTC\''
+    ).columns(now).gino.load(
+        sample + (lambda r, c: datetime.utcnow(), now,)).query)
+    assert row[:5] == sample
+    assert isinstance(row[-2], datetime)
+    assert isinstance(row[-1], datetime)
+    assert row[-1] <= row[-2]

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -92,7 +92,7 @@ async def test_func(user):
     assert u.team.company.name == user.team.company.name
 
 
-async def test_adjaceny_list(user):
+async def test_adjacency_list(user):
     Group = Team.__table__.alias()
 
     def loader(row, context):

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -1,0 +1,8 @@
+import pytest
+
+pytestmark = pytest.mark.asyncio
+
+
+@pytest.fixture
+async def data():
+    pass


### PR DESCRIPTION
As proposed in #13 and based on comments from @wwwjfy, this PR added the "loader" concept to allow user to customize how the database rows should be loaded into objects.

User should provide a loader expression or function as an execution option `loader`. Loader expressions can be recursively nested. Please see examples below:

Load a single model instance, the same as the `model` execution option (actually `model` is now an alias of this):

```python
users = await db.select([User]).execution_options(loader=User).gino.all()
```

This can be simplified as:

```python
user = await User.query.gino.load(User).all()
```

Load specified columns as a tuple (only a showcase! The reduce happens on client side, database still load all columns):

```python
name_by_id = dict(await User.query.gino.load((User.id, User.name)).all())
```

Load only one value (only showcase, you should usually use `scalar()` directly):

```python
first_name = await User.query.gino.load(User.name).first()
```

Partially load a model instance (ditto):

```python
users_with_only_id_and_name = await User.query.gino.load(User.load('id', 'name')).all()
```

Load two related model instances through a `join`:

```python
user = await User.join(Team).select().gino.load(User.load(team=Team)).first()
assert isinstance(user.team, Team)
```

Nested many-to-one relationships:

```python
query = User.join(Team).join(Company).select()
user = await query.gino.load(User.load(team=Team.load(company=Company))).first()
assert isinstance(user.team, Team)
assert isinstance(user.team.company, Company)
```

The same nested relationships with a function loader:

```python
def loader(row, context):
    rv = User(**dict((c.name, row[c]) for c in User))
    rv.team = Team(**dict((c.name, row[c]) for c in Team))
    rv.team.company = Company(**dict((c.name, row[c]) for c in Company))
    return rv

query = User.join(Team).join(Company).select()
user = await query.gino.load(loader).first()
assert isinstance(user.team, Team)
assert isinstance(user.team.company, Company)
```

Adjacency list (experimental):

```python
group = Team.alias()
query = User.join(Team).join(group, Team.parent_id == group.id).select()
user = await query.gino.load(User.load(team=Team.load(parent=group))).first()
assert isinstance(user.team, Team)
assert isinstance(user.team.parent, Team)
```