### PR TITLE
Add support for calling create() on model instances

### DIFF
--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -241,6 +241,12 @@ properties on the object::
     print(f'ID:       {user.id}')           # 1
     print(f'Nickname: {user.nickname}')     # fantix
 
+It is also possible to create a model instance in-memory first, modify it, then
+finally create it in the database::
+
+    user = User(nickname='fantix')
+    user.nickname += ' (founder)'
+    await user.create()
 
 Retrieve
 ^^^^^^^^

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -9,22 +9,41 @@ pytestmark = pytest.mark.asyncio
 
 async def test_create(engine):
     nickname = 'test_create_{}'.format(random.random())
-    u = await User.create(bind=engine, nickname=nickname,
-                          type=UserType.USER, timeout=10)
+    u = await User.create(bind=engine, timeout=10,
+                          nickname=nickname, age=42, type=UserType.USER)
     assert u.id is not None
     assert u.nickname == nickname
     assert u.type == UserType.USER
+    assert u.age == 42
+
+    u2 = await User.get(u.id, bind=engine, timeout=10)
+    assert u2.id == u.id
+    assert u2.nickname == nickname
+    assert u2.type == UserType.USER
+    assert u2.age == 42
+    assert u2 is not u
+
     return u
 
 
 async def test_create_from_instance(engine):
     nickname = 'test_create_from_instance_{}'.format(random.random())
-    u = User(nickname='will-be-replaced', type=UserType.USER)
+    u = User(nickname='will-be-replaced', type=UserType.USER, age=42)
     u.nickname = nickname
+    u.age = 21
     await u.create(bind=engine, timeout=10)
     assert u.id is not None
     assert u.nickname == nickname
     assert u.type == UserType.USER
+    assert u.age == 21
+
+    u2 = await User.get(u.id, bind=engine, timeout=10)
+    assert u2.id == u.id
+    assert u2.nickname == nickname
+    assert u2.type == UserType.USER
+    assert u2.age == 21
+    assert u2 is not u
+
     return u
 
 

--- a/tests/test_crud.py
+++ b/tests/test_crud.py
@@ -17,6 +17,17 @@ async def test_create(engine):
     return u
 
 
+async def test_create_from_instance(engine):
+    nickname = 'test_create_from_instance_{}'.format(random.random())
+    u = User(nickname='will-be-replaced', type=UserType.USER)
+    u.nickname = nickname
+    await u.create(bind=engine, timeout=10)
+    assert u.id is not None
+    assert u.nickname == nickname
+    assert u.type == UserType.USER
+    return u
+
+
 async def test_get(engine):
     u1 = await test_create(engine)
     u2 = await User.get(u1.id, bind=engine, timeout=10)
@@ -28,6 +39,12 @@ async def test_get(engine):
     assert u1.id == u3.id
     assert u1.nickname == u3.nickname
     assert u1 is not u3
+
+    u4 = await test_create_from_instance(engine)
+    u5 = await engine.first(u4.query)
+    assert u4.id == u5.id
+    assert u4.nickname == u5.nickname
+    assert u4 is not u5
 
 
 async def test_textual_sql(engine):


### PR DESCRIPTION
This PR adds support for creating model instances in-memory, modifying them, then calling create() on the instances to insert them into the database. See issue #178.

Would love some feedback.

The code seems to work, and I can modify at least Column attributes in-memory before calling create(). But when I tried modifying the "age" value of the User model in the tests, this did not work (it retained the default value of 18). I think it is because I don't understand the difference between ```Column(Unicode())``` and ```IntegerProperty()```.  Maybe you can enlighten me @fantix?

