### PR TITLE
Fix tests that failed when run against a non-default database

### DIFF
--- a/CONTRIBUTING.rst
+++ b/CONTRIBUTING.rst
@@ -111,3 +111,15 @@ Tips
 To run a subset of tests::
 
 $ py.test -svx tests.test_gino
+
+By default the tests run against a default installed postgres database. If you
+wish to run against a separate database for the tests you can do this by first
+creating a new database and user using 'psql' or similar::
+
+    CREATE ROLE gino WITH LOGIN ENCRYPTED PASSWORD 'gino';
+    CREATE DATABASE gino WITH OWNER = gino;
+
+Then run the tests like so::
+
+    export DB_USER=gino DB_PASS=gino DB_NAME=gino
+    py.test

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -31,7 +31,7 @@ async def test_basic(engine):
 
 async def test_issue_79():
     import gino
-    e = await gino.create_engine('postgresql:///non_exist', min_size=0)
+    e = await gino.create_engine(PG_URL + '_non_exist', min_size=0)
     with pytest.raises(InvalidCatalogNameError):
         async with e.acquire():
             pass  # pragma: no cover

--- a/tests/test_tornado.py
+++ b/tests/test_tornado.py
@@ -6,6 +6,8 @@ import tornado.options
 import tornado.escape
 from gino.ext.tornado import Gino, Application, GinoRequestHandler
 
+from .models import DB_ARGS
+
 
 # noinspection PyShadowingNames
 @pytest.fixture
@@ -46,6 +48,15 @@ def app():
             user = await User.create(nickname=self.get_argument('name'))
             self.write(f'Hi, {user.nickname}!')
 
+    options = {
+        'db_host': DB_ARGS['host'],
+        'db_port': DB_ARGS['port'],
+        'db_user': DB_ARGS['user'],
+        'db_password': DB_ARGS['password'],
+        'db_database': DB_ARGS['database'],
+    }
+    for option, value in options.items():
+        setattr(tornado.options.options, option, value)
     app = Application([
         tornado.web.URLSpec(r'/', AllUsers, name='index'),
         tornado.web.URLSpec(r'/user/(?P<uid>[0-9]+)', GetUser, name='user'),


### PR DESCRIPTION
This PR fixes a couple of tests that broke when running against a non-default database (i.e not 'postgres'). Also added docs in CONTRIBUTING.rst on how to run tests against a separate database.