### PR TITLE
enforce utf-8 on setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -5,10 +5,10 @@
 
 from setuptools import setup, find_packages
 
-with open('README.rst') as readme_file:
+with open('README.rst', encoding='utf-8') as readme_file:
     readme = readme_file.read()
 
-with open('HISTORY.rst') as history_file:
+with open('HISTORY.rst', encoding='utf-8') as history_file:
     history = history_file.read()
 
 

--- a/tox.ini
+++ b/tox.ini
@@ -13,6 +13,7 @@ commands=flake8 gino
 [testenv]
 passenv = TRAVIS TRAVIS_*
 setenv =
+    LC_ALL = en_US.UTF-8
     PYTHONPATH = {toxinidir}
 deps =
     -r{toxinidir}/requirements_dev.txt


### PR DESCRIPTION
in the non utf-8 environment, e.g. LANG=C, reading HISTORY.rst would
cause UnicodeDecodeError

```
Traceback (most recent call last):
  File "setup.py", line 12, in <module>
    history = history_file.read()
  File "/Users/tony/gino/.tox/py36/bin/../lib/python3.6/encodings/ascii.py", line 26, in decode
    return codecs.ascii_decode(input, self.errors)[0]
UnicodeDecodeError: 'ascii' codec can't decode byte 0xc3 in position 6577: ordinal not in range(128)
```