### PR TITLE
fix rst render in PyPI

### DIFF
--- a/HISTORY.rst
+++ b/HISTORY.rst
@@ -1,5 +1,3 @@
-.. highlight:: python3
-
 =======
 History
 =======


### PR DESCRIPTION
Setting highlight to `python3` is already done in docs/conf.py.
I don't know how to test if it affects Read the Docs.

```
$ pip install readme_renderer
$ python setup.py check -r -s
running check
warning: Check: :221: (ERROR/3) Unknown directive type "highlight".

warning: Check:

warning: Check: .. highlight:: python3

warning: Check:

warning: Check: The project's long_description has invalid markup which will not be rendered on PyPI.

error: Please correct your package.
```