### PR TITLE
Fix sphinx warnings

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -70,6 +70,7 @@ docs: ## generate Sphinx HTML documentation, including API docs
 	rm docs/modules.rst
 	$(MAKE) -C docs clean
 	$(MAKE) -C docs html
+	@echo "open file://`pwd`/docs/_build/html/index.html"
 	$(BROWSER) docs/_build/html/index.html
 
 servedocs: docs ## compile the docs watching for changes

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -97,7 +97,7 @@ html_theme = "sphinx_rtd_theme"
 # Add any paths that contain custom static files (such as style sheets) here,
 # relative to this directory. They are copied after the builtin static files,
 # so a file named "default.css" will overwrite the builtin "default.css".
-html_static_path = ['_static']
+# html_static_path = ['_static']
 
 
 # -- Options for HTMLHelp output ---------------------------------------

--- a/docs/json.rst
+++ b/docs/json.rst
@@ -1,3 +1,5 @@
+:orphan:
+
 JSON Property
 =============
 

--- a/docs/tutorial.rst
+++ b/docs/tutorial.rst
@@ -37,10 +37,10 @@ Installation
 .. important::
 
     aiocontextvars_ will be replaced by `contextvars
-    <https://github.com/MagicStack/contextvars>`_ once it `supports asyncio
+    <https://github.com/MagicStack/contextvars>`__ once it `supports asyncio
     <https://github.com/MagicStack/contextvars/issues/2>`_. And neither will be
     needed in Python 3.7 which is delivered with a builtin `contextvars
-    <https://docs.python.org/3.7/library/contextvars.html>`_ module.
+    <https://docs.python.org/3.7/library/contextvars.html>`__ module.
 
 .. _aiocontextvars: https://github.com/fantix/aiocontextvars
 
@@ -125,7 +125,7 @@ suggests singular for model names, and plural for table names. Each
 the table, where its first parameter indicates the column type in database,
 while the rest is for other column attributes or constraints. You can find a
 mapping of database types to ``db`` types `here
-<http://docs.sqlalchemy.org/en/latest/core/type_basics.html>`_ in the SQLAlchemy
+<http://docs.sqlalchemy.org/en/latest/core/type_basics.html>`__ in the SQLAlchemy
 documentation.
 
 .. note::
@@ -157,7 +157,7 @@ but are otherwise not used. Example::
 
 It is also possible to define model constraints and indexes outside the model
 class if that is preferred. For more details on constraints and indexes, see
-`here <http://docs.sqlalchemy.org/en/latest/core/constraints.html>`_ in the
+`here <http://docs.sqlalchemy.org/en/latest/core/constraints.html>`__ in the
 SQLAlchemy documentation.
 
 Due to implementation limitations it is currently not allowed to specify
@@ -192,7 +192,7 @@ Then we tell our ``db`` object to connect to this database::
 If this runs successfully, then you are connected to the newly created database.
 Here ``asyncpg`` indicates the database dialect and driver to use, ``localhost``
 is where the server is, and ``gino`` is the name of the database. Check
-`here <https://docs.sqlalchemy.org/en/latest/core/engines.html>`_ for more
+`here <https://docs.sqlalchemy.org/en/latest/core/engines.html>`__ for more
 information about how to compose this database URL.
 
 .. note::
@@ -324,7 +324,7 @@ Now let's add some filters. For example, find all users with ID lower than 10::
     # SQL (parameter: 10):
     # SELECT users.id, users.nickname FROM users WHERE users.id < $1
 
-Read more `here <https://docs.sqlalchemy.org/en/latest/core/expression_api.html>`_
+Read more `here <https://docs.sqlalchemy.org/en/latest/core/expression_api.html>`__
 about writing queries, because the query object is exactly from SQLAlchemy core.
 
 .. warning::

--- a/docs/why.rst
+++ b/docs/why.rst
@@ -122,7 +122,9 @@ some resource (time) for Thread 2. But Thread 1 also needed CPU time to finish
 its processing at the same time, so in turn after a while the OS had to pause
 Thread 2 and resume Thread 1. Depending on the size of the task, such turns may
 happen several times, so that every thread may have a fair chance to run. It is
-something like this::
+something like this:
+
+.. code-block:: none
 
     Thread 1: I wanna run!
     OS: Okay, here you go...
@@ -145,7 +147,9 @@ coroutine should run. The event manager may only trigger the next coroutine to
 run, after the previous coroutine yields control to wait for an event (e.g.
 wait for an HTTP response). This approach to achieve concurrency is called
 `cooperative multitasking
-<https://en.wikipedia.org/wiki/Cooperative_multitasking>`_. It's like this::
+<https://en.wikipedia.org/wiki/Cooperative_multitasking>`_. It's like this:
+
+.. code-block:: none
 
     Coroutine 1: Let me know when event A arrives. I'm done here before that.
     Event manager: Okay. What about you, coroutine 2?


### PR DESCRIPTION
When I built docs with `make docs` I've noticed that it gives quite a few warnings:
```
reading sources... [100%] why
../gino/docs/tutorial.rst:2: WARNING: Duplicate explicit target name: "contextvars".
../gino/docs/tutorial.rst:2: WARNING: Duplicate explicit target name: "here".
../gino/docs/tutorial.rst:2: WARNING: Duplicate explicit target name: "here".
../gino/docs/tutorial.rst:2: WARNING: Duplicate explicit target name: "here".
looking for now-outdated files... none found
pickling environment... done
checking consistency... ../gino/docs/json.rst: WARNING: document isn't included in any toctree
done
preparing documents... done
writing output... [100%] why
../gino/docs/why.rst:127: WARNING: Could not lex literal_block as "python3". Highlighting skipped.
../gino/docs/why.rst:150: WARNING: Could not lex literal_block as "python3". Highlighting skipped.
generating indices... genindex py-modindex
highlighting module code... [100%] sqlalchemy.util.langhelpers
writing additional pages... search
copying images... [100%] why_coroutine.png
copying static files... WARNING: html_static_path entry '../gino/docs/_static' does not exist
done
copying extra files... done
dumping search index in English (code: en) ... done
dumping object inventory... done
build succeeded, 8 warnings.
```

1. `Duplicate explicit target name` is for links that have same "visible name" - fix with anonymous references (double underscore). An alternative would be to name them differently.
2. `Could not lex literal_block` - that was about the coroutines dialog blocks, that have no language to highlight with.
3. since `_static` does not exist - I've commented this row out in `conf.py`. Alternative would be to create the folder and put some css in it.
4. `document isn't included in any toctree` - about `json.rst`. I don't know if it should be included somewhere or not. Added `:orphan:` metadata for sphinx to ignore it.
5. Not related to warnings - this line `@echo "open file://`pwd`/docs/_build/html/index.html"` allows to  reopen documents with manual click (my browser handles this auto-opening well, don't know about the others).