### PR TITLE
Update the relationships doc to handle the new do_load() return

### DIFF
--- a/docs/relationship.rst
+++ b/docs/relationship.rst
@@ -281,11 +281,11 @@ example through the :class:`~gino.loader.CallableLoader`::
             parent_id = row[Parent.id]
             parent = parents.get(parent_id, None)
             if parent is None:
-                parent = parent_loader.do_load(row, ctx)
+                parent, distinct = parent_loader.do_load(row, ctx)
                 parent.children = []
                 parents[parent_id] = parent
             if row[Child.id] is not None:
-                child = child_loader.do_load(row, ctx)
+                child, distinct = child_loader.do_load(row, ctx)
                 child.parent = parent  # two-way reference
                 parent.children.append(child)
 


### PR DESCRIPTION
A small PR concerning the doc :)

I was playing with the loaders feature and my tests were successful with Gino 0.7.3. When I updated my requirements Gino was upgraded to 0.7.4 and my tests failed because the `do_load()` signature has been changed : https://github.com/fantix/gino/commit/4a8c36e5654ca6960a5902171244ad3a312e89b3

`do_load()` now returns a tuple (a boolean was added) instead a single model instance.