### PR TITLE
fixed #261, map model and db column names

### DIFF
--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -197,6 +197,19 @@ more declarative. Instead of ``users.c.name``, you can now access the column by
 available at ``User.__table__`` and ``Address.__table__``. You can use anything
 that works in GINO core here.
 
+.. note::
+
+    Column names can be different as a class property and database column.
+    For example, name can be declared as
+    ``nickname = db.Column('name', db.Unicode(), default='noname')``. In this
+    example, ``User.nickname`` is used to access the column, while in database,
+    the column name is ``name``.
+
+    What's worth mentioning is where raw SQL statements are used, or
+    ``TableClause`` is involved, like ``User.insert()``, the original name is
+    required to be used, because in this case, GINO has no knowledge about the
+    mappings.
+
 .. tip::
 
     ``db.Model`` is a dynamically created parent class for your models. It is

--- a/gino/crud.py
+++ b/gino/crud.py
@@ -88,7 +88,7 @@ class UpdateRequest:
             try:
                 self._locator = instance.lookup()
             except LookupError:
-                # apply() will fail anyway, but still allow updates()
+                # apply() will fail anyway, but still allow update()
                 pass
 
     def _set(self, key, value):
@@ -144,7 +144,9 @@ class UpdateRequest:
                         sa.func.jsonb_build_object(
                             *itertools.chain(*updates.items())))
             else:
-                raise TypeError('{} is not supported.'.format(prop.type))
+                raise TypeError('{} is not supported to update json '
+                                'properties in Gino. Please consider using '
+                                'JSONB.'.format(prop.type))
 
         opts = dict(return_model=False)
         if timeout is not DEFAULT:

--- a/gino/declarative.py
+++ b/gino/declarative.py
@@ -7,18 +7,18 @@ from .exceptions import GinoException
 
 
 class ColumnAttribute:
-    def __init__(self, name, column):
-        self.name = name
+    def __init__(self, prop_name, column):
+        self.prop_name = prop_name
         self.column = column
 
     def __get__(self, instance, owner):
         if instance is None:
             return self.column
         else:
-            return instance.__values__.get(self.name)
+            return instance.__values__.get(self.prop_name)
 
     def __set__(self, instance, value):
-        instance.__values__[self.name] = value
+        instance.__values__[self.prop_name] = value
 
     def __delete__(self, instance):
         raise AttributeError('Cannot delete value.')
@@ -36,7 +36,7 @@ class InvertDict(dict):
             self._inverted_dict[v] = k
 
     def __setitem__(self, key, value):
-        if value in self._inverted_dict:
+        if value in self._inverted_dict and self._inverted_dict[value] != key:
             raise GinoException(
                 'Column name {} already maps to {}'.format(
                     value, self._inverted_dict[value]))

--- a/gino/declarative.py
+++ b/gino/declarative.py
@@ -3,10 +3,12 @@ import collections
 import sqlalchemy as sa
 from sqlalchemy.exc import InvalidRequestError
 
+from .exceptions import GinoException
+
 
 class ColumnAttribute:
-    def __init__(self, column):
-        self.name = column.name
+    def __init__(self, name, column):
+        self.name = name
         self.column = column
 
     def __get__(self, instance, owner):
@@ -20,6 +22,29 @@ class ColumnAttribute:
 
     def __delete__(self, instance):
         raise AttributeError('Cannot delete value.')
+
+
+class InvertDict(dict):
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self._inverted_dict = dict()
+        for k, v in self.items():
+            if v in self._inverted_dict:
+                raise GinoException(
+                    'Column name {} already maps to {}'.format(
+                        v, self._inverted_dict[v]))
+            self._inverted_dict[v] = k
+
+    def __setitem__(self, key, value):
+        if value in self._inverted_dict:
+            raise GinoException(
+                'Column name {} already maps to {}'.format(
+                    value, self._inverted_dict[value]))
+        super().__setitem__(key, value)
+        self._inverted_dict[value] = key
+
+    def invert_get(self, key, default=None):
+        return self._inverted_dict.get(key, default)
 
 
 class ModelType(type):
@@ -119,6 +144,7 @@ class Model:
         columns = []
         inspected_args = []
         updates = {}
+        column_name_map = InvertDict()
         for each_cls in sub_cls.__mro__[::-1]:
             for k, v in getattr(each_cls, '__namespace__',
                                 each_cls.__dict__).items():
@@ -126,11 +152,14 @@ class Model:
                     v = updates[k] = v(sub_cls)
                 if isinstance(v, sa.Column):
                     v = v.copy()
-                    v.name = k
+                    if not v.name:
+                        v.name = k
+                    column_name_map[k] = v.name
                     columns.append(v)
-                    updates[k] = sub_cls.__attr_factory__(v)
+                    updates[k] = sub_cls.__attr_factory__(k, v)
                 elif isinstance(v, (sa.Index, sa.Constraint)):
                     inspected_args.append(v)
+        sub_cls._column_name_map = column_name_map
 
         # handle __table_args__
         table_args = updates.get('__table_args__',
@@ -173,4 +202,5 @@ def inspect_model_type(target):
     return sa.inspection.inspect(target.__table__)
 
 
-__all__ = ['ColumnAttribute', 'Model', 'declarative_base', 'declared_attr']
+__all__ = ['ColumnAttribute', 'Model', 'declarative_base', 'declared_attr',
+           'InvertDict']

--- a/gino/engine.py
+++ b/gino/engine.py
@@ -15,7 +15,7 @@ if sys.version_info >= (3, 7):
     from contextvars import ContextVar
 else:
     # noinspection PyPackageRequirements
-    from aiocontextvars import ContextVar
+    from aiocontextvars import ContextVar  # pragma: no cover
 
 
 class _BaseDBAPIConnection:

--- a/gino/json_support.py
+++ b/gino/json_support.py
@@ -22,10 +22,10 @@ class Hook:
 
 
 class JSONProperty:
-    def __init__(self, default=None, column_name='profile'):
+    def __init__(self, default=None, prop_name='profile'):
         self.name = None
         self.default = default
-        self.column_name = column_name
+        self.prop_name = prop_name
         self.expression = Hook(self)
         self.after_get = Hook(self)
         self.before_set = Hook(self)
@@ -33,7 +33,7 @@ class JSONProperty:
     def __get__(self, instance, owner):
         if instance is None:
             exp = self.make_expression(
-                getattr(owner, self.column_name)[self.name])
+                getattr(owner, self.prop_name)[self.name])
             return self.expression.call(owner, exp)
         val = self.get_profile(instance).get(self.name, NONE)
         if val is NONE:
@@ -54,16 +54,16 @@ class JSONProperty:
         if instance.__profile__ is None:
             props = type(instance).__dict__
             instance.__profile__ = {}
-            for key, value in (getattr(instance, self.column_name, None)
+            for key, value in (getattr(instance, self.prop_name, None)
                                or {}).items():
                 instance.__profile__[key] = props[key].decode(value)
         return instance.__profile__
 
     def save(self, instance, value=NONE):
-        profile = getattr(instance, self.column_name, None)
+        profile = getattr(instance, self.prop_name, None)
         if profile is None:
             profile = {}
-            setattr(instance, self.column_name, profile)
+            setattr(instance, self.prop_name, profile)
         if value is NONE:
             value = instance.__profile__[self.name]
         if not isinstance(value, sa.sql.ClauseElement):
@@ -74,7 +74,7 @@ class JSONProperty:
     def reload(self, instance):
         if instance.__profile__ is None:
             return
-        profile = getattr(instance, self.column_name, None) or {}
+        profile = getattr(instance, self.prop_name, None) or {}
         value = profile.get(self.name, NONE)
         if value is NONE:
             instance.__profile__.pop(self.name, None)

--- a/gino/loader.py
+++ b/gino/loader.py
@@ -75,7 +75,11 @@ class ModelLoader(Loader):
         if none_as_none and all((v is None) for v in values.values()):
             return None
         rv = self.model()
-        rv.__values__.update(values)
+        for c in self.columns:
+            if c in row:
+                # noinspection PyProtectedMember
+                instance_key = self.model._column_name_map.invert_get(c.name)
+                rv.__values__[instance_key] = row[c]
         return rv
 
     def do_load(self, row, context):

--- a/tests/models.py
+++ b/tests/models.py
@@ -31,14 +31,14 @@ class User(db.Model):
     __tablename__ = 'gino_users'
 
     id = db.Column(db.BigInteger(), primary_key=True)
-    nickname = db.Column(db.Unicode(), default='noname')
-    profile = db.Column(JSONB(), nullable=False, server_default='{}')
+    nickname = db.Column('name', db.Unicode(), default='noname')
+    profile = db.Column('props', JSONB(), nullable=False, server_default='{}')
     type = db.Column(
         db.Enum(UserType),
         nullable=False,
         default=UserType.USER,
     )
-    name = db.StringProperty()
+    realname = db.StringProperty()
     age = db.IntegerProperty(default=18)
     balance = db.IntegerProperty(default=0)
     birthday = db.DateTimeProperty(

--- a/tests/test_aiohttp.py
+++ b/tests/test_aiohttp.py
@@ -22,7 +22,7 @@ async def _test_client(config):
         __tablename__ = 'gino_users'
 
         id = db.Column(db.BigInteger(), primary_key=True)
-        nickname = db.Column(db.Unicode(), default='noname')
+        nickname = db.Column('name', db.Unicode(), default='noname')
 
     routes = web.RouteTableDef()
 
@@ -107,8 +107,7 @@ async def _test(test_client):
         response = await test_client.get('/users/1?method=' + method)
         assert response.status == 404
 
-    response = await test_client.post('/users',
-                                      data=dict(name='fantix'))
+    response = await test_client.post('/users', data=dict(name='fantix'))
     assert response.status == 200
     assert await response.json() == dict(id=1, nickname='fantix')
 

--- a/tests/test_bind.py
+++ b/tests/test_bind.py
@@ -36,7 +36,7 @@ async def test_unbind(asyncpg_pool):
 
 async def test_db_api(bind, random_name):
     assert await db.scalar(
-        User.insert().values(nickname=random_name).returning(
+        User.insert().values(name=random_name).returning(
             User.nickname)) == random_name
     assert (await db.first(User.query.where(
         User.nickname == random_name))).nickname == random_name

--- a/tests/test_declarative.py
+++ b/tests/test_declarative.py
@@ -1,5 +1,6 @@
 import pytest
 import gino
+from gino.declarative import InvertDict
 from asyncpg.exceptions import (
     UniqueViolationError, ForeignKeyViolationError, CheckViolationError)
 
@@ -54,7 +55,7 @@ async def test_table_args():
 
 
 async def test_inline_constraints_and_indexes(bind, engine):
-    u = await User.create(name='test')
+    u = await User.create(nickname='test')
     us1 = await UserSetting.create(user_id=u.id, setting='skin', value='blue')
 
     # PrimaryKeyConstraint
@@ -222,3 +223,20 @@ async def test_abstract_model_error():
 
     with pytest.raises(TypeError, match='AbstractModel is abstract'):
         await AbstractModel.get(1)
+
+
+async def test_invert_dict():
+    with pytest.raises(gino.GinoException,
+                       match=r'Column name c1 already maps to \w+'):
+        InvertDict({'col1': 'c1', 'col2': 'c1'})
+    with pytest.raises(gino.GinoException,
+                       match=r'Column name c1 already maps to \w+'):
+        d = InvertDict()
+        d['col1'] = 'c1'
+        d['col2'] = 'c1'
+
+    d = InvertDict()
+    d['col1'] = 'c1'
+    d['col2'] = 'c2'
+    assert d.invert_get('c1') == 'col1'
+    assert d.invert_get('c2') == 'col2'

--- a/tests/test_declarative.py
+++ b/tests/test_declarative.py
@@ -229,6 +229,7 @@ async def test_invert_dict():
     with pytest.raises(gino.GinoException,
                        match=r'Column name c1 already maps to \w+'):
         InvertDict({'col1': 'c1', 'col2': 'c1'})
+
     with pytest.raises(gino.GinoException,
                        match=r'Column name c1 already maps to \w+'):
         d = InvertDict()
@@ -236,6 +237,8 @@ async def test_invert_dict():
         d['col2'] = 'c1'
 
     d = InvertDict()
+    d['col1'] = 'c1'
+    # it works for same key/value pair
     d['col1'] = 'c1'
     d['col2'] = 'c2'
     assert d.invert_get('c1') == 'col1'

--- a/tests/test_executemany.py
+++ b/tests/test_executemany.py
@@ -8,12 +8,11 @@ pytestmark = pytest.mark.asyncio
 # noinspection PyUnusedLocal
 async def test_status(bind):
     statement, params = db.compile(User.insert(),
-                                   [dict(nickname='1'), dict(nickname='2')])
-    assert statement == ('INSERT INTO gino_users (nickname, type) '
+                                   [dict(name='1'), dict(name='2')])
+    assert statement == ('INSERT INTO gino_users (name, type) '
                          'VALUES ($1, $2)')
     assert params == (('1', 'USER'), ('2', 'USER'))
-    result = await User.insert().gino.status(dict(nickname='1'),
-                                             dict(nickname='2'))
+    result = await User.insert().gino.status(dict(name='1'), dict(name='2'))
     assert result is None
     assert len(await User.query.gino.all()) == 2
 

--- a/tests/test_executemany.py
+++ b/tests/test_executemany.py
@@ -20,34 +20,49 @@ async def test_status(bind):
 # noinspection PyUnusedLocal
 async def test_all(bind):
     result = await User.insert().returning(User.nickname).gino.all(
-        dict(nickname='1'), dict(nickname='2'))
+        dict(name='1'), dict(name='2'))
     assert result is None
-    assert len(await User.query.gino.all()) == 2
+    rows = await User.query.gino.all()
+    assert len(rows) == 2
+    assert set(u.nickname for u in rows) == {'1', '2'}
 
     result = await User.insert().gino.all(
-        dict(nickname='3'), dict(nickname='4'))
+        dict(name='3'), dict(name='4'))
     assert result is None
+    rows = await User.query.gino.all()
+    assert len(rows) == 4
+    assert set(u.nickname for u in rows) == {'1', '2', '3', '4'}
 
 
 # noinspection PyUnusedLocal
 async def test_first(bind):
     result = await User.insert().returning(User.nickname).gino.first(
-        dict(nickname='1'), dict(nickname='2'))
+        dict(name='1'), dict(name='2'))
     assert result is None
+    rows = await User.query.gino.all()
     assert len(await User.query.gino.all()) == 2
+    assert set(u.nickname for u in rows) == {'1', '2'}
 
     result = await User.insert().gino.first(
-        dict(nickname='3'), dict(nickname='4'))
+        dict(name='3'), dict(name='4'))
     assert result is None
+    rows = await User.query.gino.all()
+    assert len(rows) == 4
+    assert set(u.nickname for u in rows) == {'1', '2', '3', '4'}
 
 
 # noinspection PyUnusedLocal
 async def test_scalar(bind):
     result = await User.insert().returning(User.nickname).gino.scalar(
-        dict(nickname='1'), dict(nickname='2'))
+        dict(name='1'), dict(name='2'))
     assert result is None
+    rows = await User.query.gino.all()
     assert len(await User.query.gino.all()) == 2
+    assert set(u.nickname for u in rows) == {'1', '2'}
 
     result = await User.insert().gino.scalar(
-        dict(nickname='3'), dict(nickname='4'))
+        dict(name='3'), dict(name='4'))
     assert result is None
+    rows = await User.query.gino.all()
+    assert len(rows) == 4
+    assert set(u.nickname for u in rows) == {'1', '2', '3', '4'}

--- a/tests/test_iterate.py
+++ b/tests/test_iterate.py
@@ -9,7 +9,7 @@ pytestmark = pytest.mark.asyncio
 def names(sa_engine):
     rv = {'11', '22', '33'}
     sa_engine.execute(User.__table__.insert(),
-                      [dict(nickname=name) for name in rv])
+                      [dict(name=name) for name in rv])
     yield rv
     sa_engine.execute('DELETE FROM gino_users')
 

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -102,10 +102,10 @@ async def test_non_jsonb(bind):
     try:
         news = await News.create()
         assert news.visits == 0
-        with pytest.raises(TypeError, match='JSON is not supported.'):
+        with pytest.raises(TypeError, match='JSON is not supported'):
             await news.update(visits=News.visits + 10).apply()
         assert news.visits == 0
-        with pytest.raises(TypeError, match='JSON is not supported.'):
+        with pytest.raises(TypeError, match='JSON is not supported'):
             await news.update(visits=10).apply()
         assert news.visits == 10
         assert await news.select('visits').gino.scalar() == 0
@@ -185,7 +185,7 @@ async def test_t291(bind):
         profile1 = db.Column(JSON(), nullable=False, server_default='{}')
 
         bool = db.BooleanProperty()
-        bool1 = db.BooleanProperty(column_name='profile1')
+        bool1 = db.BooleanProperty(prop_name='profile1')
 
     await PropsTest.gino.create()
     try:

--- a/tests/test_json.py
+++ b/tests/test_json.py
@@ -47,23 +47,24 @@ async def test_crud(bind):
     assert await u.query.gino.model(None).first() == (
         1, 'fantix', dict(age=16, balance=100, birthday=now_str),
         UserType.USER, None)
-    assert await db.select([User.name]).where(
+    assert await db.select([User.realname]).where(
         User.id == u.id).gino.scalar() is None
 
     # Reload and test updating both JSON and regular property
     u = await User.get(u.id)
-    await u.update(age=User.age - 2, balance=200.15, name='daisy',
-                   nickname='daisy').apply()
+    await u.update(age=User.age - 2, balance=200.15, realname='daisy',
+                   nickname='daisy.nick').apply()
     assert await u.query.gino.model(None).first() == (
-        1, 'daisy', dict(age=14, balance=200, name='daisy', birthday=now_str),
+        1, 'daisy.nick',
+        dict(age=14, balance=200, realname='daisy', birthday=now_str),
         UserType.USER, None)
     assert u.to_dict() == dict(
         age=14,
         balance=200.0,
         birthday=now,
         id=1,
-        name='daisy',
-        nickname='daisy',
+        nickname='daisy.nick',
+        realname='daisy',
         type=UserType.USER,
         team_id=None,
     )
@@ -118,12 +119,12 @@ async def test_non_jsonb(bind):
 # noinspection PyUnusedLocal
 async def test_reload(bind):
     u = await User.create()
-    await u.update(name=db.cast('888', db.Unicode)).apply()
-    assert u.name == '888'
+    await u.update(realname=db.cast('888', db.Unicode)).apply()
+    assert u.realname == '888'
     await u.update(profile=None).apply()
-    assert u.name == '888'
-    User.__dict__['name'].reload(u)
-    assert u.name is None
+    assert u.realname == '888'
+    User.__dict__['realname'].reload(u)
+    assert u.realname is None
 
 
 # noinspection PyUnusedLocal

--- a/tests/test_prepared_stmt.py
+++ b/tests/test_prepared_stmt.py
@@ -13,7 +13,7 @@ async def test_compiled_and_bindparam(bind):
             *User).execution_options(loader=User))
         users = {}
         for name in '12345':
-            u = await ins.first(nickname=name)
+            u = await ins.first(name=name)
             assert u.nickname == name
             users[u.id] = u
         get = await conn.prepare(


### PR DESCRIPTION
Basic implementation of mappings of model and db column names. By basic, I mean it passes all tests, but might not be exhaustive in all cases. If the basic idea looks fine, I'll continue on cases and docs.

Basically, this is to create a mapping on table creation, and convert back and forth on queries and loaders. Unlike sqlalchemy, which does the mapping at the beginning of every query, this will need the user to update manually in the case of column changes. I prefer this way because model changes is not a usual case, and we can save some time on queries.