### PR TITLE
fix #302, check transaction state before rollback

### DIFF
--- a/gino/dialects/asyncpg.py
+++ b/gino/dialects/asyncpg.py
@@ -3,7 +3,6 @@ import itertools
 import time
 
 import asyncpg
-from asyncpg.transaction import TransactionState
 from sqlalchemy import util, exc, sql
 from sqlalchemy.dialects.postgresql import (  # noqa: F401
     ARRAY,
@@ -243,10 +242,6 @@ class Transaction(base.Transaction):
         await self._tx.commit()
 
     async def rollback(self):
-        # noinspection PyProtectedMember
-        if self._tx._state in (TransactionState.FAILED,
-                               TransactionState.ROLLEDBACK):
-            return
         await self._tx.rollback()
 
 

--- a/gino/dialects/asyncpg.py
+++ b/gino/dialects/asyncpg.py
@@ -3,6 +3,7 @@ import itertools
 import time
 
 import asyncpg
+from asyncpg.transaction import TransactionState
 from sqlalchemy import util, exc, sql
 from sqlalchemy.dialects.postgresql import (  # noqa: F401
     ARRAY,
@@ -242,6 +243,10 @@ class Transaction(base.Transaction):
         await self._tx.commit()
 
     async def rollback(self):
+        # noinspection PyProtectedMember
+        if self._tx._state in (TransactionState.FAILED,
+                               TransactionState.ROLLEDBACK):
+            return
         await self._tx.rollback()
 
 

--- a/gino/transaction.py
+++ b/gino/transaction.py
@@ -173,7 +173,6 @@ class GinoTransaction:
             try:
                 await self._tx.commit()
             except Exception:
-                await self._tx.rollback()
                 raise
         else:
             await self._tx.rollback()

--- a/gino/transaction.py
+++ b/gino/transaction.py
@@ -166,16 +166,16 @@ class GinoTransaction:
         return self
 
     async def __aexit__(self, ex_type, ex, ex_tb):
-        try:
-            is_break = ex_type is _Break
-            if is_break and ex.commit:
-                ex_type = None
-            if ex_type is None:
+        is_break = ex_type is _Break
+        if is_break and ex.commit:
+            ex_type = None
+        if ex_type is None:
+            try:
                 await self._tx.commit()
-            else:
+            except Exception:
                 await self._tx.rollback()
-        except Exception:
+                raise
+        else:
             await self._tx.rollback()
-            raise
         if is_break and ex.tx is self:
             return True


### PR DESCRIPTION
running rollback on failed or already rolled back transactions has no
effect and asyncpg would throw exceptions