### PR TITLE
set pyup to only update minor for testing packages

### DIFF
--- a/requirements_dev.txt
+++ b/requirements_dev.txt
@@ -1,9 +1,9 @@
-pip==18.1
+pip==18.1  # pyup: update minor
 -e .
 
-bumpversion==0.5.3
-wheel==0.32.2
-cryptography==2.3.1
+bumpversion==0.5.3  # pyup: update minor
+wheel==0.32.2  # pyup: update minor
+cryptography==2.3.1  # pyup: update minor
 psycopg2-binary==2.7.5
 sanic==0.8.3
 aiohttp==3.4.4
@@ -12,18 +12,18 @@ async_generator==1.10
 quart==0.6.7;python_version>="3.6"
 
 # tests
-coverage==4.5.1
-flake8==3.5.0
-tox==3.5.2
-pytest==3.9.1
-pytest-runner==4.2
-pytest-asyncio==0.9.0
-pytest-tornado==0.5.0
-pytest-mock==1.10.0
-pytest-cov==2.6.0
+coverage==4.5.1  # pyup: update minor
+flake8==3.5.0  # pyup: update minor
+tox==3.5.2  # pyup: update minor
+pytest==3.9.1  # pyup: update minor
+pytest-runner==4.2  # pyup: update minor
+pytest-asyncio==0.9.0  # pyup: update minor
+pytest-tornado==0.5.0  # pyup: update minor
+pytest-mock==1.10.0  # pyup: update minor
+pytest-cov==2.6.0  # pyup: update minor
 
 # docs
-Sphinx==1.8.1
-Pygments==2.2.0
-sphinxcontrib-asyncio==0.2.0
-sphinx-rtd-theme==0.4.2
+Sphinx==1.8.1  # pyup: update minor
+Pygments==2.2.0  # pyup: update minor
+sphinxcontrib-asyncio==0.2.0  # pyup: update minor
+sphinx-rtd-theme==0.4.2  # pyup: update minor


### PR DESCRIPTION
This is to prevent unnecessarily frequent pyup pull requests for
packages like pytest. pyup supports checking minor updates only.