### PR TITLE
fix false warning by flake8 3.6.0

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -9,7 +9,7 @@ python =
 
 [testenv:flake8]
 basepython=python
-deps=flake8
+deps=flake8==3.5.0
 commands=flake8 gino
 
 [testenv]


### PR DESCRIPTION
pycodestyle which is contained in flake8 3.6.0 has an issue with syntax
`await (await async_func())`.
The issue was filed as https://github.com/PyCQA/pycodestyle/issues/811