### PR TITLE
fix #378, loosen SQLAlchemy version requirement

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 asyncpg==0.18.1
-SQLAlchemy==1.2.12
+SQLAlchemy>=1.2
 aiocontextvars==0.2.1


### PR DESCRIPTION
For projects having both Gino and SQLAlchemy as dependencies, this helps to solve the conflicts.