### PR TITLE
Add custom config parameter to aiohttp middleware

### DIFF
--- a/gino/ext/aiohttp.py
+++ b/gino/ext/aiohttp.py
@@ -113,7 +113,7 @@ class Gino(_Gino):
             finally:
                 request.pop('connection', None)
 
-    def init_app(self, app, config = None):
+    def init_app(self, app, config=None):
         app['db'] = self
 
         if not isinstance(config, dict):

--- a/gino/ext/aiohttp.py
+++ b/gino/ext/aiohttp.py
@@ -87,8 +87,8 @@ class Gino(_Gino):
       like ``asyncpg``. Unrecognized parameters will cause exceptions.
 
     If you would like to use a custom configuration dictionary, you can do that
-    by passing it as ``config=`` argument in ``app_init`` call. Remember to use the keys
-    described above.
+    by passing it as ``config=`` argument in ``app_init`` call. Remember to use
+    the keys described above.
 
     If the ``db`` is set as an aiohttp middleware, then a lazy connection is
     available at ``request['connection']``. By default, a database connection

--- a/gino/ext/aiohttp.py
+++ b/gino/ext/aiohttp.py
@@ -68,7 +68,7 @@ class Gino(_Gino):
         db.init_app(app)
 
     By :meth:`init_app` GINO subscribes to a few signals on aiohttp, so that
-    GINO could use database configuration in aiohttp ``config.gino`` to
+    GINO could use database configuration in aiohttp ``app['config'].gino`` to
     initialize the bound engine. The config includes:
 
     * ``driver`` - the database driver, default is ``asyncpg``.
@@ -85,6 +85,10 @@ class Gino(_Gino):
     * ``ssl`` - SSL context passed to ``asyncpg.connect``, default is ``None``.
     * ``kwargs`` - other parameters passed to the specified dialects,
       like ``asyncpg``. Unrecognized parameters will cause exceptions.
+
+    If you would like to use a custom configuration dictionary, you can do that
+    by passing it as ``config=`` argument in ``app_init`` call. Remember to use the keys
+    described above.
 
     If the ``db`` is set as an aiohttp middleware, then a lazy connection is
     available at ``request['connection']``. By default, a database connection

--- a/gino/ext/aiohttp.py
+++ b/gino/ext/aiohttp.py
@@ -118,6 +118,8 @@ class Gino(_Gino):
 
         if not isinstance(config, dict):
             config = app['config'].get('gino', {})
+        else:
+            config = config.copy()
 
         async def before_server_start(app_):
             if config.get('dsn'):

--- a/gino/ext/aiohttp.py
+++ b/gino/ext/aiohttp.py
@@ -109,10 +109,11 @@ class Gino(_Gino):
             finally:
                 request.pop('connection', None)
 
-    def init_app(self, app):
+    def init_app(self, app, config = None):
         app['db'] = self
 
-        config = app['config'].get('gino', {})
+        if not isinstance(config, dict):
+            config = app['config'].get('gino', {})
 
         async def before_server_start(app_):
             if config.get('dsn'):


### PR DESCRIPTION
This change adds additional ``config`` parameter to ``init_app`` function in aiohttp middleware class. This way middleware can be independent from the config format used by the project using it. Parameter has a default value set to ``None``, so it shouldn't break any existing implementations of the described middleware and as of now accepts only dictionaries. Small note is added to the middleware class docstring.