### PR TITLE
Unpin dependency versions

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-asyncpg==0.18.3
-SQLAlchemy>=1.2
-aiocontextvars==0.2.1
+asyncpg~=0.18
+SQLAlchemy>=1.2,<1.3
+aiocontextvars~=0.2


### PR DESCRIPTION
* #378 we may not release as fast as dependencies, so it makes sense to unpin the versions.
* #433 when fixed, we should then use `SQLAlchemy~=1.2`