### PR TITLE
Support for one() and one_or_none()

### DIFF
--- a/docs/engine.rst
+++ b/docs/engine.rst
@@ -384,9 +384,11 @@ Executing Queries
 -----------------
 
 Once you have a :class:`~gino.engine.GinoConnection` instance, you can start
-executing queries with it. There are 4 variants of the execute method:
+executing queries with it. There are 6 variants of the execute method:
 :meth:`~gino.engine.GinoConnection.all`,
 :meth:`~gino.engine.GinoConnection.first`,
+:meth:`~gino.engine.GinoConnection.one`,
+:meth:`~gino.engine.GinoConnection.one_or_none`,
 :meth:`~gino.engine.GinoConnection.scalar` and
 :meth:`~gino.engine.GinoConnection.status`. They are basically the same:
 accepting the same parameters, calling the same underlying methods. The
@@ -399,6 +401,11 @@ difference is how they treat the results:
   or ``None`` if there is no result at all. There is usually some optimization
   behind the scene to efficiently get only the first result, instead of loading
   the full result set into memory.
+* :meth:`~gino.engine.GinoConnection.one` returns exactly one result. If there
+  is no result at all or if there are multiple results, an exception is raised.
+* :meth:`~gino.engine.GinoConnection.one_or_none` is similar to
+  :meth:`~gino.engine.GinoConnection.one`, but it returns ``None`` if there is
+  no result instead or raising an exception.
 * :meth:`~gino.engine.GinoConnection.scalar` is similar to
   :meth:`~gino.engine.GinoConnection.first`, it returns the first value of the
   first result. Quite convenient to just retrieve a scalar value from database,

--- a/docs/schema.rst
+++ b/docs/schema.rst
@@ -79,6 +79,10 @@ but return a bit differently. There are also other similar query APIs:
   :class:`~sqlalchemy.engine.RowProxy`
 * :meth:`~gino.engine.GinoConnection.first` returns one
   :class:`~sqlalchemy.engine.RowProxy`, or ``None``
+* :meth:`~gino.engine.GinoConnection.one` returns one
+  :class:`~sqlalchemy.engine.RowProxy`
+* :meth:`~gino.engine.GinoConnection.one_or_none` returns one
+  :class:`~sqlalchemy.engine.RowProxy`, or ``None``
 * :meth:`~gino.engine.GinoConnection.scalar` returns a single value, or
   ``None``
 * :meth:`~gino.engine.GinoConnection.iterate` returns an asynchronous iterator

--- a/gino/api.py
+++ b/gino/api.py
@@ -25,8 +25,9 @@ class GinoExecutor:
         await User.query.gino.first()
 
     This allows GINO to add the asynchronous query APIs (:meth:`all`,
-    :meth:`first`, :meth:`scalar`, :meth:`status`, :meth:`iterate`) to
-    SQLAlchemy query clauses without messing up with existing synchronous ones.
+    :meth:`first`, :meth:`one`, :meth:`one_or_none`, :meth:`scalar`,
+    :meth:`status`, :meth:`iterate`) to SQLAlchemy query clauses without
+    messing up with existing synchronous ones.
     Calling these asynchronous query APIs has the same restriction - the
     relevant metadata (the :class:`Gino` instance) must be bound to an engine,
     or an :exc:`AttributeError` will be raised.
@@ -134,6 +135,28 @@ class GinoExecutor:
         """
         return await self._query.bind.first(self._query, *multiparams,
                                             **params)
+
+    async def one_or_none(self, *multiparams, **params):
+        """
+        Returns :meth:`engine.one_or_none() <.engine.GinoEngine.one_or_none>`
+        with this query as the first argument, and other arguments followed,
+        where ``engine`` is the :class:`~.engine.GinoEngine` to which the
+        metadata (:class:`Gino`) is bound, while metadata is found in this
+        query.
+
+        """
+        return await self._query.bind.one_or_none(self._query, *multiparams,
+                                                  **params)
+
+    async def one(self, *multiparams, **params):
+        """
+        Returns :meth:`engine.one() <.engine.GinoEngine.one>` with this query
+        as the first argument, and other arguments followed, where ``engine``
+        is the :class:`~.engine.GinoEngine` to which the metadata
+        (:class:`Gino`) is bound, while metadata is found in this query.
+
+        """
+        return await self._query.bind.one(self._query, *multiparams, **params)
 
     async def scalar(self, *multiparams, **params):
         """
@@ -450,6 +473,21 @@ class Gino(sa.MetaData):
 
         """
         return await self.bind.first(clause, *multiparams, **params)
+
+    async def one_or_none(self, clause, *multiparams, **params):
+        """
+        A delegate of :meth:`GinoEngine.one_or_none()
+        <.engine.GinoEngine.one_or_none>`.
+
+        """
+        return await self.bind.one_or_none(clause, *multiparams, **params)
+
+    async def one(self, clause, *multiparams, **params):
+        """
+        A delegate of :meth:`GinoEngine.one() <.engine.GinoEngine.first>`.
+
+        """
+        return await self.bind.one(clause, *multiparams, **params)
 
     async def scalar(self, clause, *multiparams, **params):
         """

--- a/gino/exceptions.py
+++ b/gino/exceptions.py
@@ -12,3 +12,11 @@ class UninitializedError(GinoException):
 
 class UnknownJSONPropertyError(GinoException):
     pass
+
+
+class MultipleResultsFound(GinoException):
+    pass
+
+
+class NoResultFound(GinoException):
+    pass

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -23,6 +23,8 @@ async def test_basic(engine):
     assert isinstance(await engine.scalar(sa.text('select now()')), datetime)
     assert isinstance((await engine.first('select now()'))[0], datetime)
     assert isinstance((await engine.all('select now()'))[0][0], datetime)
+    assert isinstance((await engine.one('select now()'))[0], datetime)
+    assert isinstance((await engine.one_or_none('select now()'))[0], datetime)
     status, result = await engine.status('select now()')
     assert status == 'SELECT 1'
     assert isinstance(result[0][0], datetime)

--- a/tests/test_loader.py
+++ b/tests/test_loader.py
@@ -45,6 +45,25 @@ async def test_scalar(user):
     assert user.nickname == name
 
 
+async def test_one_or_none(user):
+    name = await User.query.gino.load(User.nickname).one_or_none()
+    assert user.nickname == name
+
+    uid, name = await (User.query.gino.load((User.id, User.nickname))
+                       .one_or_none())
+    assert user.id == uid
+    assert user.nickname == name
+
+
+async def test_one(user):
+    name = await User.query.gino.load(User.nickname).one()
+    assert user.nickname == name
+
+    uid, name = await User.query.gino.load((User.id, User.nickname)).one()
+    assert user.id == uid
+    assert user.nickname == name
+
+
 async def test_model_load(user):
     u = await User.query.gino.load(User.load('nickname', User.team_id)).first()
     assert isinstance(u, User)


### PR DESCRIPTION
Implement `one` and `one_or_none` methods for `GinoConnection`.

This is similar to the corresponding [SQLAlchemy methods](https://docs.sqlalchemy.org/en/13/orm/query.html#sqlalchemy.orm.query.Query.one).

Fixes #385