### PR TITLE
Extend documentation for running tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -158,11 +158,13 @@ Contribute
 There are a few tasks in GitHub issues marked as ``help wanted``. Please feel
 free to take any of them and pull requests are greatly welcome.
 
-To run tests (please read more in CONTRIBUTING.rst):
+To run tests:
 
 .. code-block:: console
 
    $ python setup.py test
+
+For the tests to be run, a database has to be available (please read more in CONTRIBUTING.rst)
 
 Meanwhile, these are also very much appreciated:
 


### PR DESCRIPTION
Postgres has to run with ssl for many of the tests to succeed. I added commands to the contributing documentation to explain how to do this.

It's not so nice that the required files are created in the directory from which the commands are executed instead of in the docker container. I can probably cobble something something together that replaces the entrypoint in the postgres container to prevent that but it seemed a little overkill.

Let me know if this is useful! Or if I have simply missed something basic and this is not actually necessary at all?